### PR TITLE
Create new enforce_value_in_range config option, disable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Bar Card is a customizable animated card for the Home Assistant Lovelace front-e
 | columns | number | none | Number of columns when using entities list.
 | attribute | string | none | Attribute to be displayed.
 | show_value | boolean | true | Hides value display when set to `false`.
+| enforce_value_in_range | boolean | false | Ensure the value is always within the minimum and maximum when set to `true`.
 | show_minmax | boolean | false | Hides the minimum and maximum value when set to `false`.
 | unit_of_measurement | string | none | Unit of measurement to be displayed.
 | color | string | var(--primary-color) | Color of the bar, can be any valid CSS color value or variable.

--- a/bar-card.js
+++ b/bar-card.js
@@ -24,6 +24,7 @@ class BarCard extends HTMLElement {
     if (!config.color) config.color = 'var(--primary-color)'
     if (!config.tap_action) config.tap_action = 'info'
     if (!config.show_value) config.show_value = true
+    if (!config.enforce_value_in_range) config.enforce_value_in_range = false
     if (!config.show_minmax) config.show_minmax = false
     if (!config.title) config.title = false
     if (!config.severity) config.severity = false
@@ -999,7 +1000,7 @@ class BarCard extends HTMLElement {
       } else {
         entityState = entityObject.state
       }
-      if (!isNaN(entityState)) {
+      if (config.enforce_value_in_range && !isNaN(entityState)) {
       entityState = Math.min(entityState, configMax)
       entityState = Math.max(entityState, configMin)
       }


### PR DESCRIPTION
I've started using bar-card to display the temperature of my house and the desired minimum and maximum temperature. This does, however, mean that the temperature can be outside this range until the house has heated/cooled enough. Because bar-card automatically forces the value to be within the minimum and maximum, this breaks my use case. This small patch fixes it.

I've also disabled this old behaviour by default, because I assume people will generally want to see the real value unless they explicitly mention to want it post-processed to always be within min and max. If you disagree, I'll change the default back to match the old behaviour by default.

Before (true value hidden):
![image](https://user-images.githubusercontent.com/1885159/62076373-d22b8380-b247-11e9-91d1-f1c32cddab6d.png)

After (true value shown):
![image](https://user-images.githubusercontent.com/1885159/62076348-c17b0d80-b247-11e9-9c03-b04161bd79bf.png)