### PR TITLE
Create --custom-bar-card-color variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Bar Card is a customizable animated card for the Home Assistant Lovelace front-e
 | show_minmax | boolean | false | Shows the minimum and maximum value when set to `true`.
 | decimal | number | false | The amount of decimals to be displayed for the value. Shows full number when set to `false`.
 | unit_of_measurement | string | none | Unit of measurement to be displayed.
-| color | string | var(--primary-color) | Color of the bar, can be any valid CSS color value or variable.
+| color | string | var(--custom-bar-card-color, var(--primary-color)) | Color of the bar, can be any valid CSS color value or variable. Custom themes should set `custom-bar-card-color` if `primary-color` is not a good default
 | title | string | friendly_name | Title displayed next to the bar.
 | title_position | string | left | Position of the title. `left`, `right`, `top`, `bottom`, `inside`, `'off'`
 | icon | string | icon | Icon to be displayed. If no icon is defined entity icon attribute will be used. 

--- a/bar-card.js
+++ b/bar-card.js
@@ -21,7 +21,7 @@ class BarCard extends HTMLElement {
     if (!config.max) config.max = 100
     if (!config.padding) config.padding = '4px'
     if (!config.align) config.align = 'center'
-    if (!config.color) config.color = 'var(--primary-color)'
+    if (!config.color) config.color = 'var(--custom-bar-card-color, var(--primary-color))'
     if (!config.tap_action) config.tap_action = 'info'
     if (!config.show_value) config.show_value = true
     if (!config.limit_value) config.limit_value = false


### PR DESCRIPTION
Meant for themes to be able to set sensible defaults where --primary-color isn't a good fit.

In the [synthwave theme](https://github.com/bbbenji/synthwave-hass) it currently looks like this:
<img width="360" alt="Screenshot 2019-08-16 at 09 40 44" src="https://user-images.githubusercontent.com/1885159/63151537-0229a380-c00a-11e9-87d2-a6138522480c.png">

Thus, I want themes to be able to set sensible defaults so I can fix it directly in the theme :)