### PR TITLE
Fix example in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ style: |-
     font-weight: bold;
     text-shadow: 1px 1px #0005;
   }
+  bar-card-currentbar, bar-card-backgroundbar {
+    border-radius: 4px;
+  }
 ```
 
 ### Custom CSS Layout (**requires** [card-mod](https://github.com/thomasloven/lovelace-card-mod))


### PR DESCRIPTION
border-radius as shown in screen was missing in example code

Fixes https://github.com/custom-cards/bar-card/issues/137 and https://github.com/custom-cards/bar-card/issues/156